### PR TITLE
[project] Adds readme and repo fields to pyproject.toml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ jobs:
   tests:
     name: "Tests for Python ${{ matrix.python-version }} on ${{ matrix.os }}"
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.9]
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,23 @@ locations = "trello_reports", "tests", "noxfile.py"
 nox.options.sessions = "lint", "typing", "tests"
 
 
-@nox.session(python=["3.9", "3.8", "3.7"])
+@nox.session(python=["3.9"])
+def lint(session):
+    args = session.posargs or locations
+    session.install("flake8", "black", "poetry")
+    session.run("flake8", *args)
+    session.run("black", "--check", "--diff", *args)
+    session.run("poetry", "check")
+
+
+@nox.session(python=["3.9"])
+def typing(session):
+    args = session.posargs or locations
+    session.install("mypy")
+    session.run("mypy", *args)
+
+
+@nox.session(python=["3.9"])
 def tests(session):
     args = session.posargs or ["--cov"]
     session.run("poetry", "install", external=True)
@@ -12,22 +28,7 @@ def tests(session):
 
 
 @nox.session
-def lint(session):
-    args = session.posargs or locations
-    session.install("flake8", "black")
-    session.run("flake8", *args)
-    session.run("black", "--check --diff", *args)
-
-
-@nox.session
 def format(session):
     args = session.posargs or locations
     session.install("black")
     session.run("black", *args)
-
-
-@nox.session
-def typing(session):
-    args = session.posargs or locations
-    session.install("mypy")
-    session.run("mypy", *args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "CLI tool to generate reports from trello kanban boards"
 authors = ["Rodrigo Machuca <rmachuca89@hotmail.com>"]
 license = "MIT"
+readme = "README.md"
+repository = "https://github.com/rmachuca89/trello-reports"
+keywords = ["trello"]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Also, enable poetry check to nox lint session

Main reason was to fix the following error when publishing to test PyPI:

```
Checking dist/trello_reports-0.1.1.dev1627252873-py3-none-any.whl: FAILED
  `long_description` has syntax errors in markup and would not be rendered on PyPI.
  warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
Checking dist/trello-reports-0.1.1.dev1627252873.tar.gz: PASSED, with warnings
  warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
  warning: `long_description` missing.
```